### PR TITLE
Compiles on T4 Beta

### DIFF
--- a/TouchScreen.h
+++ b/TouchScreen.h
@@ -8,13 +8,17 @@
 #include <stdint.h>
 
 
-#if defined(__AVR_ATmega328P__) || defined(__AVR_ATmega32U4__) || defined(TEENSYDUINO)
+#if defined(__AVR_ATmega328P__) || defined(__AVR_ATmega32U4__) || defined(TEENSYDUINO) || defined(__AVR_ATmega2560__)
+#if defined(__IMXRT1052__) || defined(__IMXRT1062__)
+typedef volatile uint32_t RwReg;
+#else
 typedef volatile uint8_t RwReg;
+#endif
 #endif
 #if defined(ARDUINO_STM32_FEATHER)
 typedef volatile uint32 RwReg;
 #endif
-#if defined(ARDUINO_FEATHER52)
+#if defined(ARDUINO_FEATHER52) || defined(ESP32)
 typedef volatile uint32_t RwReg;
 #endif
 


### PR DESCRIPTION
Add in defines to look for IMXRT...
In that case rwReg is 32 bits instead of 8 bits

I also pulled in the more recent stuff from Adafruit... ESP32 and ATmega2560)
